### PR TITLE
fix(deploy): lint only source files and ignore built artifacts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+dist
+build
+public
+node_modules
+/*.min.js

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -64,7 +64,8 @@ jobs:
           # run prettier then eslint autofix
           if command -v npx >/dev/null 2>&1; then
             npx prettier --check . || npx prettier --write . || true
-            npx eslint . --ext .js,.jsx,.ts,.tsx --fix || true
+            # Lint only source files to avoid scanning built artifacts in dist/ or build/
+            npx eslint "src/**/*.{js,jsx,ts,tsx}" --fix || true
           fi
 
           # commit back to the PR branch when changes exist and repo is same

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -141,6 +141,8 @@
   - `micromatch` (ReDoS, moderate) surfaced via `lint-staged`. Fixed by upgrading `lint-staged` to `16.1.5` in `package.json`.
   - Post-fix audit report shows zero vulnerabilities (see `audit_report_after2.json`).
 
+- 2025-08-24: Fixed Deploy to GitHub Pages workflow to avoid linting built artifacts. Added `.eslintignore` to exclude `dist`, `build`, `public`, and `node_modules` from CI linting to prevent false-positive errors on bundled output.
+
 - Notes:
   - If you maintain the Husky hooks, run `npm run prepare` locally after `npm install` to ensure hooks are installed.
   - For any force audit fixes (`npm audit fix --force`), prefer creating a targeted branch/PR (`fix/security/<issue>`) and run full CI validation before merging.


### PR DESCRIPTION
Limit ESLint in deploy workflow to source files and add .eslintignore to avoid linting build artifacts (dist/build/public).