### PR TITLE
fix: avoid heredoc syntax error in deploy workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -164,20 +164,7 @@ jobs:
           else
             # Fallback: create a placeholder so the deploy action has something to push
             mkdir -p public
-            cat > public/index.html <<'HTML'
-            <!doctype html>
-            <html>
-              <head>
-                <meta charset="utf-8">
-                <meta name="viewport" content="width=device-width,initial-scale=1">
-                <title>Empty GitHub Pages site</title>
-              </head>
-              <body>
-                <h1>This site was deployed from GitHub Actions</h1>
-                <p>No build artifact was found; the workflow generated this placeholder page.</p>
-              </body>
-            </html>
-            HTML
+            printf "%b" "<!doctype html>\n<html>\n  <head>\n    <meta charset=\"utf-8\">\n    <meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\n    <title>Empty GitHub Pages site</title>\n  </head>\n  <body>\n    <h1>This site was deployed from GitHub Actions</h1>\n    <p>No build artifact was found; the workflow generated this placeholder page.</p>\n  </body>\n</html>" > public/index.html
             echo "publish_dir=public" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
Replace heredoc with printf to avoid runner heredoc indentation syntax errors; ensures deploy job doesn't fail on placeholder creation.